### PR TITLE
Turn the body of build_prep into a function

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,11 @@ for documentation build:
         make
 
 ### Building rpm package
-1.  run build\_prep.sh for .spec file substitution and tarball creation:
-            sh build_prep.sh
+1.  run build\_prep.py for .spec file substitution and tarball creation:
+            python build_prep.py
+    or run the following code in Python:
+            import build_prep
+            build_prep.prepare()
 2.  copy libcomps.spec and libcomps-(git_commit_rev).tar.xz to SPECS and
     SOURCES dirs
             cp libcomps-*.tar.xz <PATH_TO_YOUR_RPMBUILD_SOURCES_DIR>/

--- a/build_prep.py
+++ b/build_prep.py
@@ -123,20 +123,13 @@ def build_chlog(tags ,top='HEAD'):
         log.append("\n".join(_log))
     return reversed(log)
 
-if __name__ == "__main__":
+def prepare(ref='HEAD'):
     vfp = open("version.json", "r")
     version = json.load(vfp)
     vfp.close()
     
     subs = {}
-    try:
-        top_commit = tag_to_commit(sys.argv[1])
-        subs["GITREVLONG"] = tag_to_commit(sys.arv[1])
-    except IndexError:
-        top_commit = tag_to_commit("HEAD")
-        subs["GITREVLONG"] = tag_to_commit(top_commit)
-
-
+    top_commit = subs["GITREVLONG"] = tag_to_commit(ref)
 
     subs.update(version)
     tags = git_tags_chrono()
@@ -166,3 +159,6 @@ if __name__ == "__main__":
                           archive_name])#,
                          #stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     p.wait()
+
+if __name__ == "__main__":
+    prepare(next(iter(sys.argv[1:]), 'HEAD'))


### PR DESCRIPTION
This makes it possible to call the `build_prep` functionality from Python. It will help us to build libcomps nightly builds.

Let me know if there is any problem/ugliness. E.g. you may want to turn `next(iter(sys.argv[1:]), 'HEAD')` into something more readable.